### PR TITLE
Add slack and rocketchat notification commands

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -21,5 +21,7 @@ var addVariableCmd = &cobra.Command{
 func init() {
 	addCmd.AddCommand(addVariableCmd)
 	addCmd.AddCommand(addSlackNotificationCmd)
+	addCmd.AddCommand(addProjectSlackNotificationCmd)
 	addCmd.AddCommand(addRocketChatNotificationCmd)
+	addCmd.AddCommand(addProjectRocketChatNotificationCmd)
 }

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -20,6 +20,8 @@ var deleteVariableCmd = &cobra.Command{
 
 func init() {
 	deleteCmd.AddCommand(deleteVariableCmd)
+	deleteCmd.AddCommand(deleteProjectSlackNotificationCmd)
 	deleteCmd.AddCommand(deleteSlackNotificationCmd)
+	deleteCmd.AddCommand(deleteProjectRocketChatNotificationCmd)
 	deleteCmd.AddCommand(deleteRocketChatNotificationCmd)
 }

--- a/cmd/notifications.go
+++ b/cmd/notifications.go
@@ -43,7 +43,6 @@ var listSlackCmd = &cobra.Command{
 				os.Exit(1)
 			}
 		}
-
 		var dataMain output.Table
 		err = json.Unmarshal([]byte(returnedJSON), &dataMain)
 		if err != nil {
@@ -91,7 +90,6 @@ var listRocketChatsCmd = &cobra.Command{
 				os.Exit(1)
 			}
 		}
-
 		var dataMain output.Table
 		err = json.Unmarshal([]byte(returnedJSON), &dataMain)
 		if err != nil {
@@ -107,97 +105,151 @@ var listRocketChatsCmd = &cobra.Command{
 }
 
 var addSlackNotificationCmd = &cobra.Command{
-	Use:   "slack [project name] [webhook url] [channel] [notification name]",
-	Short: "Add a new slack notification to project",
+	Use:   "slack [notification name] [channel] [webhook url]",
+	Short: "Add a new slack notification",
 	Run: func(cmd *cobra.Command, args []string) {
-		var projectName string
-		var webhookURL string
-		var channel string
 		var notificationName string
-		if len(args) < 4 {
-			if cmdProject.Name != "" && len(args) == 3 {
-				projectName = cmdProject.Name
-				webhookURL = args[0]
-				channel = args[1]
-				notificationName = args[2]
-			} else {
-				fmt.Println("Not enough arguments. Requires: project name and environment name")
-				cmd.Help()
-				os.Exit(1)
-			}
-		} else {
-			projectName = args[0]
-			webhookURL = args[1]
-			channel = args[2]
-			notificationName = args[3]
+		var channel string
+		var webhookURL string
+		if len(args) < 3 {
+			fmt.Println("Not enough arguments. Requires: notifcation name, channel, and webhook url")
+			cmd.Help()
+			os.Exit(1)
 		}
-
-		addResult, err := projects.AddSlackNotificationToProject(projectName, webhookURL, channel, notificationName)
+		notificationName = args[0]
+		channel = args[1]
+		webhookURL = args[2]
+		addResult, err := projects.AddSlackNotification(notificationName, channel, webhookURL)
 		if err != nil {
 			output.RenderError(err.Error(), outputOptions)
 			os.Exit(1)
 		}
-		var addedProject api.NotificationSlack
-		err = json.Unmarshal([]byte(addResult), &addedProject)
-
+		var resultMap map[string]interface{}
+		err = json.Unmarshal([]byte(addResult), &resultMap)
 		if err != nil {
 			output.RenderError(err.Error(), outputOptions)
 			os.Exit(1)
 		}
 		resultData := output.Result{
-			Result: "success",
+			Result:     "success",
+			ResultData: resultMap,
+		}
+		output.RenderResult(resultData, outputOptions)
+	},
+}
+
+var addProjectSlackNotificationCmd = &cobra.Command{
+	Use:   "project-slack [project name] [notification name]",
+	Short: "Add a slack notification to a project",
+	Run: func(cmd *cobra.Command, args []string) {
+		var projectName string
+		var notificationName string
+		if len(args) < 2 {
+			if cmdProject.Name != "" && len(args) == 1 {
+				projectName = cmdProject.Name
+				notificationName = args[0]
+			} else {
+				fmt.Println("Not enough arguments. Requires: project name and notification name")
+				cmd.Help()
+				os.Exit(1)
+			}
+		} else {
+			projectName = args[0]
+			notificationName = args[1]
+		}
+		addResult, err := projects.AddSlackNotificationToProject(projectName, notificationName)
+		if err != nil {
+			output.RenderError(err.Error(), outputOptions)
+			os.Exit(1)
+		}
+		var resultMap map[string]interface{}
+		err = json.Unmarshal([]byte(addResult), &resultMap)
+		if err != nil {
+			output.RenderError(err.Error(), outputOptions)
+			os.Exit(1)
+		}
+		resultData := output.Result{
+			Result:     "success",
+			ResultData: resultMap,
 		}
 		output.RenderResult(resultData, outputOptions)
 	},
 }
 
 var addRocketChatNotificationCmd = &cobra.Command{
-	Use:   "rocketchat [project name] [webhook url] [channel] [notification name]",
-	Short: "Add a new rocketchat notification to project",
+	Use:   "rocketchat [notification name] [channel] [webhook url]",
+	Short: "Add a new rocketchat notification",
 	Run: func(cmd *cobra.Command, args []string) {
-		var projectName string
-		var webhookURL string
-		var channel string
 		var notificationName string
-		if len(args) < 4 {
-			if cmdProject.Name != "" && len(args) == 3 {
-				projectName = cmdProject.Name
-				webhookURL = args[0]
-				channel = args[1]
-				notificationName = args[2]
-			} else {
-				fmt.Println("Not enough arguments. Requires: project name and environment name")
-				cmd.Help()
-				os.Exit(1)
-			}
-		} else {
-			projectName = args[0]
-			webhookURL = args[1]
-			channel = args[2]
-			notificationName = args[3]
+		var channel string
+		var webhookURL string
+		if len(args) < 3 {
+			fmt.Println("Not enough arguments. Requires: notifcation name, channel, and webhook url")
+			cmd.Help()
+			os.Exit(1)
 		}
-
-		addResult, err := projects.AddRocketChatNotificationToProject(projectName, webhookURL, channel, notificationName)
+		notificationName = args[0]
+		channel = args[1]
+		webhookURL = args[2]
+		addResult, err := projects.AddRocketChatNotification(notificationName, channel, webhookURL)
 		if err != nil {
 			output.RenderError(err.Error(), outputOptions)
 			os.Exit(1)
 		}
-		var addedProject api.NotificationSlack
-		err = json.Unmarshal([]byte(addResult), &addedProject)
-
+		var resultMap map[string]interface{}
+		err = json.Unmarshal([]byte(addResult), &resultMap)
 		if err != nil {
 			output.RenderError(err.Error(), outputOptions)
 			os.Exit(1)
 		}
 		resultData := output.Result{
-			Result: "success",
+			Result:     "success",
+			ResultData: resultMap,
 		}
 		output.RenderResult(resultData, outputOptions)
 	},
 }
 
-var deleteSlackNotificationCmd = &cobra.Command{
-	Use:   "slack [project name] [notification name]",
+var addProjectRocketChatNotificationCmd = &cobra.Command{
+	Use:   "project-rocketchat [project name] [notification name]",
+	Short: "Add a rocketchat notification to a project",
+	Run: func(cmd *cobra.Command, args []string) {
+		var projectName string
+		var notificationName string
+		if len(args) < 2 {
+			if cmdProject.Name != "" && len(args) == 1 {
+				projectName = cmdProject.Name
+				notificationName = args[0]
+			} else {
+				fmt.Println("Not enough arguments. Requires: project name and notification name")
+				cmd.Help()
+				os.Exit(1)
+			}
+		} else {
+			projectName = args[0]
+			notificationName = args[1]
+		}
+		addResult, err := projects.AddRocketChatNotificationToProject(projectName, notificationName)
+		if err != nil {
+			output.RenderError(err.Error(), outputOptions)
+			os.Exit(1)
+		}
+		var resultMap map[string]interface{}
+		err = json.Unmarshal([]byte(addResult), &resultMap)
+		if err != nil {
+			output.RenderError(err.Error(), outputOptions)
+			os.Exit(1)
+		}
+		resultData := output.Result{
+			Result:     "success",
+			ResultData: resultMap,
+		}
+		output.RenderResult(resultData, outputOptions)
+	},
+}
+
+var deleteProjectSlackNotificationCmd = &cobra.Command{
+	Use:   "project-slack [project name] [notification name]",
 	Short: "Delete a slack notification from a project",
 	Run: func(cmd *cobra.Command, args []string) {
 		var projectName string
@@ -215,7 +267,6 @@ var deleteSlackNotificationCmd = &cobra.Command{
 			projectName = args[0]
 			notificationName = args[1]
 		}
-
 		deleteResult, err := projects.DeleteSlackNotificationFromProject(projectName, notificationName)
 		if err != nil {
 			output.RenderError(err.Error(), outputOptions)
@@ -223,7 +274,6 @@ var deleteSlackNotificationCmd = &cobra.Command{
 		}
 		var addedProject api.NotificationSlack
 		err = json.Unmarshal([]byte(deleteResult), &addedProject)
-
 		if err != nil {
 			output.RenderError(err.Error(), outputOptions)
 			os.Exit(1)
@@ -235,8 +285,8 @@ var deleteSlackNotificationCmd = &cobra.Command{
 	},
 }
 
-var deleteRocketChatNotificationCmd = &cobra.Command{
-	Use:   "rocketchat [project name] [notification name]",
+var deleteProjectRocketChatNotificationCmd = &cobra.Command{
+	Use:   "project-rocketchat [project name] [notification name]",
 	Short: "Delete a rocketchat notification from a project",
 	Run: func(cmd *cobra.Command, args []string) {
 		var projectName string
@@ -254,7 +304,6 @@ var deleteRocketChatNotificationCmd = &cobra.Command{
 			projectName = args[0]
 			notificationName = args[1]
 		}
-
 		deleteResult, err := projects.DeleteRocketChatNotificationFromProject(projectName, notificationName)
 		if err != nil {
 			output.RenderError(err.Error(), outputOptions)
@@ -262,13 +311,121 @@ var deleteRocketChatNotificationCmd = &cobra.Command{
 		}
 		var addedProject api.NotificationSlack
 		err = json.Unmarshal([]byte(deleteResult), &addedProject)
-
 		if err != nil {
 			output.RenderError(err.Error(), outputOptions)
 			os.Exit(1)
 		}
 		resultData := output.Result{
 			Result: "success",
+		}
+		output.RenderResult(resultData, outputOptions)
+	},
+}
+var deleteRocketChatNotificationCmd = &cobra.Command{
+	Use:   "rocketchat [notification name]",
+	Short: "Delete a rocketchat notification from lagoon",
+	Run: func(cmd *cobra.Command, args []string) {
+		var notificationName string
+		if len(args) < 1 {
+			fmt.Println("Not enough arguments. Requires: notification name")
+			cmd.Help()
+			os.Exit(1)
+		}
+		notificationName = args[0]
+		deleteResult, err := projects.DeleteRocketChatNotification(notificationName)
+		if err != nil {
+			output.RenderError(err.Error(), outputOptions)
+			os.Exit(1)
+		}
+		if err != nil {
+			output.RenderError(err.Error(), outputOptions)
+			os.Exit(1)
+		}
+		resultData := output.Result{
+			Result: string(deleteResult),
+		}
+		output.RenderResult(resultData, outputOptions)
+	},
+}
+
+var deleteSlackNotificationCmd = &cobra.Command{
+	Use:   "slack [notification name]",
+	Short: "Delete a slack notification from lagoon",
+	Run: func(cmd *cobra.Command, args []string) {
+		var notificationName string
+		if len(args) < 1 {
+			fmt.Println("Not enough arguments. Requires: notification name")
+			cmd.Help()
+			os.Exit(1)
+		}
+		notificationName = args[0]
+		deleteResult, err := projects.DeleteSlackNotification(notificationName)
+		if err != nil {
+			output.RenderError(err.Error(), outputOptions)
+			os.Exit(1)
+		}
+		resultData := output.Result{
+			Result: string(deleteResult),
+		}
+		output.RenderResult(resultData, outputOptions)
+	},
+}
+
+var updateRocketChatNotificationCmd = &cobra.Command{
+	Use:   "rocketchat [notification name]",
+	Short: "Update an existing rocketchat notification",
+	Run: func(cmd *cobra.Command, args []string) {
+		var notificationName string
+		if len(args) < 1 {
+			fmt.Println("Not enough arguments. Requires: project name")
+			cmd.Help()
+			os.Exit(1)
+		}
+		notificationName = args[0]
+		updateResult, err := projects.UpdateRocketChatNotification(notificationName, jsonPatch)
+		if err != nil {
+			output.RenderError(err.Error(), outputOptions)
+			os.Exit(1)
+		}
+		var resultMap map[string]interface{}
+		err = json.Unmarshal([]byte(updateResult), &resultMap)
+		if err != nil {
+			output.RenderError(err.Error(), outputOptions)
+			os.Exit(1)
+		}
+		resultData := output.Result{
+			Result:     "success",
+			ResultData: resultMap,
+		}
+		output.RenderResult(resultData, outputOptions)
+	},
+}
+
+var updateSlackNotificationCmd = &cobra.Command{
+	Use:   "slack [notification name]",
+	Short: "Update an existing slack notification",
+	Run: func(cmd *cobra.Command, args []string) {
+		var notificationName string
+		if len(args) < 1 {
+			fmt.Println("Not enough arguments. Requires: project name")
+			cmd.Help()
+			os.Exit(1)
+		}
+		notificationName = args[0]
+		updateResult, err := projects.UpdateSlackNotification(notificationName, jsonPatch)
+		if err != nil {
+			output.RenderError(err.Error(), outputOptions)
+			os.Exit(1)
+		}
+		var resultMap map[string]interface{}
+		err = json.Unmarshal([]byte(updateResult), &resultMap)
+		if err != nil {
+			output.RenderError(err.Error(), outputOptions)
+			os.Exit(1)
+		}
+		resultData := output.Result{
+			Result:     "success",
+			ResultData: resultMap,
 		}
 		output.RenderResult(resultData, outputOptions)
 	},

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -10,3 +10,10 @@ var updateCmd = &cobra.Command{
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 	},
 }
+
+func init() {
+	updateCmd.AddCommand(updateSlackNotificationCmd)
+	updateSlackNotificationCmd.Flags().StringVarP(&jsonPatch, "json", "j", "", "JSON string to patch")
+	updateCmd.AddCommand(updateRocketChatNotificationCmd)
+	updateRocketChatNotificationCmd.Flags().StringVarP(&jsonPatch, "json", "j", "", "JSON string to patch")
+}

--- a/lagoon/projects/notifications.go
+++ b/lagoon/projects/notifications.go
@@ -16,8 +16,6 @@ func ListAllProjectRocketChats(projectName string) ([]byte, error) {
 	if err != nil {
 		return []byte(""), err
 	}
-
-	// get rocketchat project info from lagoon
 	project := api.Project{
 		Name: projectName,
 	}
@@ -51,15 +49,13 @@ func ListAllProjectRocketChats(projectName string) ([]byte, error) {
 	return returnResult, nil
 }
 
-// ListAllProjectSlacks will list all rocketchat notifications for a project
+// ListAllProjectSlacks will list all slack notifications for a project
 func ListAllProjectSlacks(projectName string) ([]byte, error) {
 	// set up a lagoonapi client
 	lagoonAPI, err := graphql.LagoonAPI()
 	if err != nil {
 		return []byte(""), err
 	}
-
-	// get rocketchat project info from lagoon
 	project := api.Project{
 		Name: projectName,
 	}
@@ -93,15 +89,13 @@ func ListAllProjectSlacks(projectName string) ([]byte, error) {
 	return returnResult, nil
 }
 
-// ListAllSlacks will list all rocketchat notifications for a project
+// ListAllSlacks will list all slack notifications on all projects
 func ListAllSlacks() ([]byte, error) {
 	// set up a lagoonapi client
 	lagoonAPI, err := graphql.LagoonAPI()
 	if err != nil {
 		return []byte(""), err
 	}
-
-	// get rocketchat project info from lagoon
 	customReq := api.CustomRequest{
 		Query: `query {
 			allProjects {
@@ -163,15 +157,13 @@ func ListAllSlacks() ([]byte, error) {
 	return returnResult, nil
 }
 
-// ListAllRocketChats will list all rocketchat notifications for a project
+// ListAllRocketChats will list all rocketchat notifications on all projects
 func ListAllRocketChats() ([]byte, error) {
 	// set up a lagoonapi client
 	lagoonAPI, err := graphql.LagoonAPI()
 	if err != nil {
 		return []byte(""), err
 	}
-
-	// get rocketchat project info from lagoon
 	customReq := api.CustomRequest{
 		Query: `query {
 			allProjects {
@@ -233,16 +225,13 @@ func ListAllRocketChats() ([]byte, error) {
 	return returnResult, nil
 }
 
-// AddSlackNotificationToProject will list all environments for a project
-func AddSlackNotificationToProject(projectName string, webhookURL string, channel string, notificationName string) ([]byte, error) {
-
+// AddSlackNotification will add a slack notification to lagoon to be used by a project
+func AddSlackNotification(notificationName string, channel string, webhookURL string) ([]byte, error) {
 	// set up a lagoonapi client
 	lagoonAPI, err := graphql.LagoonAPI()
 	if err != nil {
 		return []byte(""), err
 	}
-
-	// run the query to add the environment variable to lagoon
 	customReq := api.CustomRequest{
 		Query: `mutation ($name: String!, $channel: String!, $webhook: String!) {
 			addNotificationSlack(input:{name: $name, channel: $channel, webhook: $webhook}
@@ -261,9 +250,17 @@ func AddSlackNotificationToProject(projectName string, webhookURL string, channe
 	if err != nil {
 		return []byte(""), err
 	}
+	return returnResult, nil
+}
 
-	// run the query to add the environment variable to lagoon
-	customReq = api.CustomRequest{
+// AddSlackNotificationToProject will add a notification to a project
+func AddSlackNotificationToProject(projectName string, notificationName string) ([]byte, error) {
+	// set up a lagoonapi client
+	lagoonAPI, err := graphql.LagoonAPI()
+	if err != nil {
+		return []byte(""), err
+	}
+	customReq := api.CustomRequest{
 		Query: `mutation ($name: String!, $project: String!) {
 			addNotificationToProject(input:{notificationName: $name, notificationType: SLACK, project: $project}
 			){
@@ -276,23 +273,20 @@ func AddSlackNotificationToProject(projectName string, webhookURL string, channe
 		},
 		MappedResult: "addNotificationToProject",
 	}
-	returnResult, err = lagoonAPI.Request(customReq)
+	returnResult, err := lagoonAPI.Request(customReq)
 	if err != nil {
 		return []byte(""), err
 	}
 	return returnResult, nil
 }
 
-// DeleteSlackNotification will list all environments for a project
+// DeleteSlackNotification will delete a slack notification from lagoon
 func DeleteSlackNotification(notificationName string) ([]byte, error) {
-
 	// set up a lagoonapi client
 	lagoonAPI, err := graphql.LagoonAPI()
 	if err != nil {
 		return []byte(""), err
 	}
-
-	// run the query to add the environment variable to lagoon
 	customReq := api.CustomRequest{
 		Query: `mutation ($name: String!) {
 			deleteNotificationSlack(input:{name: $name})
@@ -309,14 +303,13 @@ func DeleteSlackNotification(notificationName string) ([]byte, error) {
 	return returnResult, nil
 }
 
-// DeleteSlackNotificationFromProject will list all environments for a project
+// DeleteSlackNotificationFromProject will delete a slack notification from a project
 func DeleteSlackNotificationFromProject(projectName string, notificationName string) ([]byte, error) {
 	// set up a lagoonapi client
 	lagoonAPI, err := graphql.LagoonAPI()
 	if err != nil {
 		return []byte(""), err
 	}
-
 	// get project info from lagoon, we need the project ID for later
 	project := api.Project{
 		Name: projectName,
@@ -330,8 +323,6 @@ func DeleteSlackNotificationFromProject(projectName string, notificationName str
 	if err != nil {
 		return []byte(""), err
 	}
-
-	// run the query to add the environment variable to lagoon
 	customReq := api.CustomRequest{
 		Query: `mutation ($name: String!, $project: String!) {
 			removeNotificationFromProject(input:{notificationName: $name, project: $project, notificationType: SLACK})
@@ -352,19 +343,16 @@ func DeleteSlackNotificationFromProject(projectName string, notificationName str
 	return returnResult, nil
 }
 
-// AddRocketChatNotificationToProject will list all environments for a project
-func AddRocketChatNotificationToProject(projectName string, webhookURL string, channel string, notificationName string) ([]byte, error) {
-
+// AddRocketChatNotification will add a rocketchat notification to lagoon to be used by a project
+func AddRocketChatNotification(notificationName string, channel string, webhookURL string) ([]byte, error) {
 	// set up a lagoonapi client
 	lagoonAPI, err := graphql.LagoonAPI()
 	if err != nil {
 		return []byte(""), err
 	}
-
-	// run the query to add the environment variable to lagoon
 	customReq := api.CustomRequest{
 		Query: `mutation ($name: String!, $channel: String!, $webhook: String!) {
-			addNotificationSlack(input:{name: $name, channel: $channel, webhook: $webhook}
+			addNotificationRocketChat(input:{name: $name, channel: $channel, webhook: $webhook}
 			){
 				id
 			}
@@ -374,15 +362,23 @@ func AddRocketChatNotificationToProject(projectName string, webhookURL string, c
 			"channel": channel,
 			"webhook": webhookURL,
 		},
-		MappedResult: "addNotificationSlack",
+		MappedResult: "addNotificationRocketChat",
 	}
 	returnResult, err := lagoonAPI.Request(customReq)
 	if err != nil {
 		return []byte(""), err
 	}
+	return returnResult, nil
+}
 
-	// run the query to add the environment variable to lagoon
-	customReq = api.CustomRequest{
+// AddRocketChatNotificationToProject will add a rocketchat notification to a project
+func AddRocketChatNotificationToProject(projectName string, notificationName string) ([]byte, error) {
+	// set up a lagoonapi client
+	lagoonAPI, err := graphql.LagoonAPI()
+	if err != nil {
+		return []byte(""), err
+	}
+	customReq := api.CustomRequest{
 		Query: `mutation ($name: String!, $project: String!) {
 			addNotificationToProject(input:{notificationName: $name, notificationType: ROCKETCHAT, project: $project}
 			){
@@ -395,23 +391,20 @@ func AddRocketChatNotificationToProject(projectName string, webhookURL string, c
 		},
 		MappedResult: "addNotificationToProject",
 	}
-	returnResult, err = lagoonAPI.Request(customReq)
+	returnResult, err := lagoonAPI.Request(customReq)
 	if err != nil {
 		return []byte(""), err
 	}
 	return returnResult, nil
 }
 
-// DeleteRocketChatNotification will list all environments for a project
+// DeleteRocketChatNotification will delete a rocketchat notification from lagoon
 func DeleteRocketChatNotification(notificationName string) ([]byte, error) {
-
 	// set up a lagoonapi client
 	lagoonAPI, err := graphql.LagoonAPI()
 	if err != nil {
 		return []byte(""), err
 	}
-
-	// run the query to add the environment variable to lagoon
 	customReq := api.CustomRequest{
 		Query: `mutation ($name: String!) {
 			deleteNotificationRocketChat(input:{name: $name})
@@ -428,14 +421,13 @@ func DeleteRocketChatNotification(notificationName string) ([]byte, error) {
 	return returnResult, nil
 }
 
-// DeleteRocketChatNotificationFromProject will list all environments for a project
+// DeleteRocketChatNotificationFromProject will delete a rocketchat notification from a project
 func DeleteRocketChatNotificationFromProject(projectName string, notificationName string) ([]byte, error) {
 	// set up a lagoonapi client
 	lagoonAPI, err := graphql.LagoonAPI()
 	if err != nil {
 		return []byte(""), err
 	}
-
 	// get project info from lagoon, we need the project ID for later
 	project := api.Project{
 		Name: projectName,
@@ -449,8 +441,6 @@ func DeleteRocketChatNotificationFromProject(projectName string, notificationNam
 	if err != nil {
 		return []byte(""), err
 	}
-
-	// run the query to add the environment variable to lagoon
 	customReq := api.CustomRequest{
 		Query: `mutation ($name: String!, $project: String!) {
 			removeNotificationFromProject(input:{notificationName: $name, project: $project, notificationType: ROCKETCHAT})
@@ -463,6 +453,65 @@ func DeleteRocketChatNotificationFromProject(projectName string, notificationNam
 			"project": projectName,
 		},
 		MappedResult: "removeNotificationFromProject",
+	}
+	returnResult, err := lagoonAPI.Request(customReq)
+	if err != nil {
+		return []byte(""), err
+	}
+	return returnResult, nil
+}
+
+// UpdateSlackNotification will update an existing notification
+func UpdateSlackNotification(notificationName string, jsonPatch string) ([]byte, error) {
+	// set up a lagoonapi client
+	lagoonAPI, err := graphql.LagoonAPI()
+	if err != nil {
+		return []byte(""), err
+	}
+	var updateSlack api.UpdateNotificationSlackPatch
+
+	err = json.Unmarshal([]byte(jsonPatch), &updateSlack)
+	customReq := api.CustomRequest{
+		Query: `mutation ($name: String!, $patch: UpdateNotificationSlackPatchInput!) {
+			updateNotificationSlack(input:{name: $name, patch: $patch}
+			){
+				id
+			}
+		}`,
+		Variables: map[string]interface{}{
+			"name":  notificationName,
+			"patch": updateSlack,
+		},
+		MappedResult: "updateNotificationSlack",
+	}
+	returnResult, err := lagoonAPI.Request(customReq)
+	if err != nil {
+		return []byte(""), err
+	}
+	return returnResult, nil
+}
+
+// UpdateRocketChatNotification will update an existing notification
+func UpdateRocketChatNotification(notificationName string, jsonPatch string) ([]byte, error) {
+	// set up a lagoonapi client
+	lagoonAPI, err := graphql.LagoonAPI()
+	if err != nil {
+		return []byte(""), err
+	}
+	var updateRocketChat api.UpdateNotificationRocketChatPatch
+	err = json.Unmarshal([]byte(jsonPatch), &updateRocketChat)
+	customReq := api.CustomRequest{
+		Query: `mutation ($name: String!, $patch: UpdateNotificationRocketChatPatchInput!) {
+			updateNotificationRocketChat(input:{name: $name, patch: $patch}
+			){
+				id
+			}
+		}`,
+		Variables: map[string]interface{}{
+			"name":  notificationName,
+			"patch": updateRocketChat,
+		},
+		MappedResult: "updateNotificationRocketChat",
 	}
 	returnResult, err := lagoonAPI.Request(customReq)
 	if err != nil {

--- a/output/main.go
+++ b/output/main.go
@@ -73,14 +73,14 @@ func RenderResult(result Result, opts Options) {
 			fmt.Println(fmt.Sprintf("Result: %s", aurora.Green(trimQuotes(result.Result))))
 			if len(result.ResultData) != 0 {
 				for k, v := range result.ResultData {
-					fmt.Println(fmt.Sprintf("%s: %s", k, v))
+					fmt.Println(fmt.Sprintf("%s: %v", k, v))
 				}
 			}
 		} else {
 			fmt.Println(fmt.Sprintf("Result: %s", aurora.Yellow(trimQuotes(result.Result))))
 			if len(result.ResultData) != 0 {
 				for k, v := range result.ResultData {
-					fmt.Println(fmt.Sprintf("%s: %s", k, v))
+					fmt.Println(fmt.Sprintf("%s: %v", k, v))
 				}
 			}
 		}


### PR DESCRIPTION
# Description
This PR adds or updates the following commands. Adding, removing and updating slack or rocketchat notifications is now possible. Listing notifications by project, or all projects is also possible
```
add slack
add project-slack
add rocketchat
add project-rocketchat
delete slack
delete project-slack
delete rocketchat
delete project-rocketchat
update slack
update rocketchat
list slack
list rocketchat
```

# Closing Issues
closes #3 