### PR TITLE
Add commands to run and list tasks

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -645,6 +645,7 @@ type Environment struct {
 	MonitoringUrls       string                `json:"monitoringUrls,omitempty"`
 	EnvVariables         []EnvironmentVariable `json:"envVariables,omitempty"`
 	Backups              []Backup              `json:"backups,omitempty"`
+	Tasks                []Task                `json:"tasks,omitempty"`
 	Project              int                   `json:"project,omitempty"`
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -105,6 +105,7 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
 	rootCmd.AddCommand(updateCmd)
 	rootCmd.AddCommand(listCmd)
 	rootCmd.AddCommand(getCmd)
+	rootCmd.AddCommand(runCmd)
 	rootCmd.AddCommand(deployEnvCmd)
 	// rootCmd.AddCommand(sshEnvCmd) //@TODO
 	rootCmd.AddCommand(webCmd)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var runCmd = &cobra.Command{
+	Use:     "run",
+	Aliases: []string{"r"},
+	Short:   "Run a task against an environment",
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		validateToken(viper.GetString("current")) // get a new token if the current one is invalid
+	},
+}
+
+func init() {
+	runCmd.AddCommand(runDrushArchiveDump)
+	runCmd.AddCommand(runDrushSQLDump)
+	runCmd.AddCommand(runDrushCacheClear)
+}

--- a/cmd/tasks.go
+++ b/cmd/tasks.go
@@ -1,0 +1,98 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/amazeeio/lagoon-cli/lagoon/environments"
+	"github.com/amazeeio/lagoon-cli/output"
+	"github.com/spf13/cobra"
+)
+
+var runDrushArchiveDump = &cobra.Command{
+	Use:     "drush-archivedump",
+	Aliases: []string{"dard"},
+	Short:   "Run a drush archive dump on an environment",
+	Run: func(cmd *cobra.Command, args []string) {
+		if cmdProjectName == "" || cmdProjectEnvironment == "" {
+			fmt.Println("Not enough arguments. Requires: project name and environment name")
+			cmd.Help()
+			os.Exit(1)
+		}
+		taskResult, err := environments.RunDrushArchiveDump(cmdProjectName, cmdProjectEnvironment)
+		if err != nil {
+			output.RenderError(err.Error(), outputOptions)
+			os.Exit(1)
+		}
+		var resultMap map[string]interface{}
+		err = json.Unmarshal([]byte(taskResult), &resultMap)
+		if err != nil {
+			output.RenderError(err.Error(), outputOptions)
+			os.Exit(1)
+		}
+		resultData := output.Result{
+			Result:     "success",
+			ResultData: resultMap,
+		}
+		output.RenderResult(resultData, outputOptions)
+	},
+}
+
+var runDrushSQLDump = &cobra.Command{
+	Use:     "drush-sqldump",
+	Aliases: []string{"dsqld"},
+	Short:   "Run a drush sql dump on an environment",
+	Run: func(cmd *cobra.Command, args []string) {
+		if cmdProjectName == "" || cmdProjectEnvironment == "" {
+			fmt.Println("Not enough arguments. Requires: project name and environment name")
+			cmd.Help()
+			os.Exit(1)
+		}
+		taskResult, err := environments.RunDrushSQLDump(cmdProjectName, cmdProjectEnvironment)
+		if err != nil {
+			output.RenderError(err.Error(), outputOptions)
+			os.Exit(1)
+		}
+		var resultMap map[string]interface{}
+		err = json.Unmarshal([]byte(taskResult), &resultMap)
+		if err != nil {
+			output.RenderError(err.Error(), outputOptions)
+			os.Exit(1)
+		}
+		resultData := output.Result{
+			Result:     "success",
+			ResultData: resultMap,
+		}
+		output.RenderResult(resultData, outputOptions)
+	},
+}
+
+var runDrushCacheClear = &cobra.Command{
+	Use:     "drush-cacheclear",
+	Aliases: []string{"dcc"},
+	Short:   "Run a drush cache clear on an environment",
+	Run: func(cmd *cobra.Command, args []string) {
+		if cmdProjectName == "" || cmdProjectEnvironment == "" {
+			fmt.Println("Not enough arguments. Requires: project name and environment name")
+			cmd.Help()
+			os.Exit(1)
+		}
+		taskResult, err := environments.RunDrushCacheClear(cmdProjectName, cmdProjectEnvironment)
+		if err != nil {
+			output.RenderError(err.Error(), outputOptions)
+			os.Exit(1)
+		}
+		var resultMap map[string]interface{}
+		err = json.Unmarshal([]byte(taskResult), &resultMap)
+		if err != nil {
+			output.RenderError(err.Error(), outputOptions)
+			os.Exit(1)
+		}
+		resultData := output.Result{
+			Result:     "success",
+			ResultData: resultMap,
+		}
+		output.RenderResult(resultData, outputOptions)
+	},
+}

--- a/lagoon/environments/tasks.go
+++ b/lagoon/environments/tasks.go
@@ -1,0 +1,293 @@
+package environments
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/amazeeio/lagoon-cli/api"
+	"github.com/amazeeio/lagoon-cli/graphql"
+	"github.com/amazeeio/lagoon-cli/output"
+)
+
+// RunDrushArchiveDump will trigger a drush archive dump task
+func RunDrushArchiveDump(projectName string, environmentName string) ([]byte, error) {
+	// set up a lagoonapi client
+	lagoonAPI, err := graphql.LagoonAPI()
+	if err != nil {
+		return []byte(""), err
+	}
+
+	// get project info from lagoon, we need the project ID for later
+	project := api.Project{
+		Name: projectName,
+	}
+	projectByName, err := lagoonAPI.GetProjectByName(project, graphql.ProjectByNameFragment)
+	if err != nil {
+		return []byte(""), err
+	}
+	var projectInfo api.Project
+	err = json.Unmarshal([]byte(projectByName), &projectInfo)
+	if err != nil {
+		return []byte(""), err
+	}
+
+	// get the environment info from lagoon, we need the environment ID for later
+	// we consume the project ID here
+	environment := api.EnvironmentByName{
+		Name:    environmentName,
+		Project: projectInfo.ID,
+	}
+	environmentByName, err := lagoonAPI.GetEnvironmentByName(environment, "")
+	if err != nil {
+		return []byte(""), err
+	}
+	var environmentInfo api.Environment
+	err = json.Unmarshal([]byte(environmentByName), &environmentInfo)
+	if err != nil {
+		return []byte(""), err
+	}
+
+	// run the query to add the environment variable to lagoon
+	customReq := api.CustomRequest{
+		Query: `mutation runArdTask ($environment: Int!) {
+			taskDrushArchiveDump(environment: $environment) {
+				id
+			}
+		}`,
+		Variables: map[string]interface{}{
+			"environment": environmentInfo.ID,
+		},
+		MappedResult: "taskDrushArchiveDump",
+	}
+	returnResult, err := lagoonAPI.Request(customReq)
+	if err != nil {
+		return []byte(""), err
+	}
+	return returnResult, nil
+}
+
+// RunDrushSQLDump will trigger a drush archive dump task
+func RunDrushSQLDump(projectName string, environmentName string) ([]byte, error) {
+	// set up a lagoonapi client
+	lagoonAPI, err := graphql.LagoonAPI()
+	if err != nil {
+		return []byte(""), err
+	}
+
+	// get project info from lagoon, we need the project ID for later
+	project := api.Project{
+		Name: projectName,
+	}
+	projectByName, err := lagoonAPI.GetProjectByName(project, graphql.ProjectByNameFragment)
+	if err != nil {
+		return []byte(""), err
+	}
+	var projectInfo api.Project
+	err = json.Unmarshal([]byte(projectByName), &projectInfo)
+	if err != nil {
+		return []byte(""), err
+	}
+
+	// get the environment info from lagoon, we need the environment ID for later
+	// we consume the project ID here
+	environment := api.EnvironmentByName{
+		Name:    environmentName,
+		Project: projectInfo.ID,
+	}
+	environmentByName, err := lagoonAPI.GetEnvironmentByName(environment, "")
+	if err != nil {
+		return []byte(""), err
+	}
+	var environmentInfo api.Environment
+	err = json.Unmarshal([]byte(environmentByName), &environmentInfo)
+	if err != nil {
+		return []byte(""), err
+	}
+
+	// run the query to add the environment variable to lagoon
+	customReq := api.CustomRequest{
+		Query: `mutation runSqlDump ($environment: Int!) {
+			taskDrushSqlDump(environment: $environment) {
+				id
+			}
+		}`,
+		Variables: map[string]interface{}{
+			"environment": environmentInfo.ID,
+		},
+		MappedResult: "taskDrushSqlDump",
+	}
+	returnResult, err := lagoonAPI.Request(customReq)
+	if err != nil {
+		return []byte(""), err
+	}
+	return returnResult, nil
+}
+
+// RunDrushCacheClear will trigger a drush archive dump task
+func RunDrushCacheClear(projectName string, environmentName string) ([]byte, error) {
+	// set up a lagoonapi client
+	lagoonAPI, err := graphql.LagoonAPI()
+	if err != nil {
+		return []byte(""), err
+	}
+
+	// get project info from lagoon, we need the project ID for later
+	project := api.Project{
+		Name: projectName,
+	}
+	projectByName, err := lagoonAPI.GetProjectByName(project, graphql.ProjectByNameFragment)
+	if err != nil {
+		return []byte(""), err
+	}
+	var projectInfo api.Project
+	err = json.Unmarshal([]byte(projectByName), &projectInfo)
+	if err != nil {
+		return []byte(""), err
+	}
+
+	// get the environment info from lagoon, we need the environment ID for later
+	// we consume the project ID here
+	environment := api.EnvironmentByName{
+		Name:    environmentName,
+		Project: projectInfo.ID,
+	}
+	environmentByName, err := lagoonAPI.GetEnvironmentByName(environment, "")
+	if err != nil {
+		return []byte(""), err
+	}
+	var environmentInfo api.Environment
+	err = json.Unmarshal([]byte(environmentByName), &environmentInfo)
+	if err != nil {
+		return []byte(""), err
+	}
+
+	// run the query to add the environment variable to lagoon
+	customReq := api.CustomRequest{
+		Query: `mutation runCacheClear ($environment: Int!) {
+			taskDrushCacheClear(environment: $environment) {
+				id
+			}
+		}`,
+		Variables: map[string]interface{}{
+			"environment": environmentInfo.ID,
+		},
+		MappedResult: "taskDrushCacheClear",
+	}
+	returnResult, err := lagoonAPI.Request(customReq)
+	if err != nil {
+		return []byte(""), err
+	}
+	return returnResult, nil
+}
+
+// GetEnvironmentTasks .
+func GetEnvironmentTasks(projectName string, environmentName string) ([]byte, error) {
+	lagoonAPI, err := graphql.LagoonAPI()
+	if err != nil {
+		return []byte(""), err
+	}
+
+	// get project info from lagoon, we need the project ID for later
+	project := api.Project{
+		Name: projectName,
+	}
+	projectByName, err := lagoonAPI.GetProjectByName(project, graphql.ProjectNameID)
+	if err != nil {
+		return []byte(""), err
+	}
+	var projectInfo api.Project
+	err = json.Unmarshal([]byte(projectByName), &projectInfo)
+	if err != nil {
+		return []byte(""), err
+	}
+
+	customRequest := api.CustomRequest{
+		Query: `query ($project: Int!, $name: String!){
+			environmentByName(
+					project: $project
+					name: $name
+			){
+				tasks{
+					name
+					id
+					remoteId
+					status
+					created
+					started
+					completed
+				}
+			}
+		}`,
+		Variables: map[string]interface{}{
+			"name":    environmentName,
+			"project": projectInfo.ID,
+		},
+		MappedResult: "environmentByName",
+	}
+	environmentByName, err := lagoonAPI.Request(customRequest)
+	fmt.Println(string(environmentByName))
+	returnResult, err := processEnvironmentTasks(environmentByName)
+	if err != nil {
+		return []byte(""), err
+	}
+	return returnResult, nil
+}
+
+func processEnvironmentTasks(environmentByName []byte) ([]byte, error) {
+	var environment api.Environment
+	err := json.Unmarshal([]byte(environmentByName), &environment)
+	if err != nil {
+		return []byte(""), errors.New("no data returned from lagoon") // @TODO could be a permissions thing when no data is returned
+	}
+	// process the data for output
+	data := []output.Data{}
+	for _, task := range environment.Tasks {
+		remoteID := task.RemoteID
+		taskID := strconv.Itoa(task.ID)
+		taskName := strings.Replace(task.Name, " ", "_", -1) //remove spaces to make friendly for parsing with awk
+		taskStatus := string(task.Status)
+		taskCreated := string(task.Created)
+		taskStarted := string(task.Started)
+		taskComplete := string(task.Completed)
+		taskService := task.Service
+		if len(remoteID) == 0 {
+			remoteID = "-"
+		}
+		if len(taskID) == 0 {
+			taskID = "-"
+		}
+		if len(taskStatus) == 0 {
+			taskStatus = "-"
+		}
+		if len(taskCreated) == 0 {
+			taskCreated = "-"
+		}
+		if len(taskStarted) == 0 {
+			taskStarted = "-"
+		}
+		if len(taskComplete) == 0 {
+			taskComplete = "-"
+		}
+		if len(taskService) == 0 {
+			taskService = "-"
+		}
+		data = append(data, []string{
+			taskID,
+			remoteID,
+			taskName,
+			taskStatus,
+			taskCreated,
+			taskStarted,
+			taskComplete,
+			taskService,
+		})
+	}
+	dataMain := output.Table{
+		Header: []string{"ID", "RemoteID", "Name", "Status", "Created", "Started", "Completed", "Service"},
+		Data:   data,
+	}
+	return json.Marshal(dataMain)
+}

--- a/lagoon/environments/tasks.go
+++ b/lagoon/environments/tasks.go
@@ -3,7 +3,6 @@ package environments
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -228,7 +227,6 @@ func GetEnvironmentTasks(projectName string, environmentName string) ([]byte, er
 		MappedResult: "environmentByName",
 	}
 	environmentByName, err := lagoonAPI.Request(customRequest)
-	fmt.Println(string(environmentByName))
 	returnResult, err := processEnvironmentTasks(environmentByName)
 	if err != nil {
 		return []byte(""), err

--- a/lagoon/environments/tasks_test.go
+++ b/lagoon/environments/tasks_test.go
@@ -1,0 +1,25 @@
+package environments
+
+import (
+	"testing"
+)
+
+func TestListEnvironmentTassks(t *testing.T) {
+	var all = `{"tasks":[
+		{"completed":null,"created":"2019-11-10 22:04:58","id":31,"name":"Drush cache-clear","remoteId":null,"started":null,"status":"failed"},
+		{"completed":"2018-10-07 23:13:41","created":"2018-10-07 23:02:41","id":5,"name":"Drupal Archive","remoteId":null,"started":"2018-10-07 23:03:41","status":"succeeded"},
+		{"completed":"2018-10-07 23:05:41","created":"2018-10-07 23:02:41","id":6,"name":"Drupal Archive","remoteId":null,"started":"2018-10-07 23:03:41","status":"failed"},
+		{"completed":null,"created":"2018-10-07 23:02:41","id":7,"name":"Site Status","remoteId":null,"started":"2018-10-07 23:03:41","status":"active"},
+		{"completed":null,"created":"2018-10-07 23:02:41","id":4,"name":"Site Status","remoteId":null,"started":"2018-10-07 23:03:41","status":"active"},
+		{"completed":null,"created":"2018-10-07 23:02:41","id":16,"name":"Site Status","remoteId":"600abdae-003f-11ea-bcee-02d6ad974cf2","started":"2018-10-07 23:03:41","status":"active"}
+	]}`
+	var allSuccess = `{"header":["ID","RemoteID","Name","Status","Created","Started","Completed","Service"],"data":[["31","-","Drush_cache-clear","failed","2019-11-10 22:04:58","-","-","-"],["5","-","Drupal_Archive","succeeded","2018-10-07 23:02:41","2018-10-07 23:03:41","2018-10-07 23:13:41","-"],["6","-","Drupal_Archive","failed","2018-10-07 23:02:41","2018-10-07 23:03:41","2018-10-07 23:05:41","-"],["7","-","Site_Status","active","2018-10-07 23:02:41","2018-10-07 23:03:41","-","-"],["4","-","Site_Status","active","2018-10-07 23:02:41","2018-10-07 23:03:41","-","-"],["16","600abdae-003f-11ea-bcee-02d6ad974cf2","Site_Status","active","2018-10-07 23:02:41","2018-10-07 23:03:41","-","-"]]}`
+
+	testResult, err := processEnvironmentTasks([]byte(all))
+	if err != nil {
+		t.Error("Should not fail if processing succeeded", err)
+	}
+	if string(testResult) != allSuccess {
+		checkEqual(t, string(testResult), allSuccess, "projectInfo processing failed")
+	}
+}


### PR DESCRIPTION
# Description
This PR adds the commands to be able to run and list tasks
### List tasks
```
$ lagoon list tasks -p high-cotton -e master
ID	REMOTEID	NAME              	STATUS   	CREATED            	STARTED            	COMPLETED          	SERVICE 
29	-       	Drush_archive-dump	failed   	2019-11-10 22:04:41	-                  	-                  	-      	
28	-       	Drush_archive-dump	failed   	2019-11-10 21:43:38	-                  	-                  	-      	
6 	-       	Drupal_Archive    	failed   	2018-10-07 23:02:41	2018-10-07 23:03:41	2018-10-07 23:05:41	-      	
7 	-       	Site_Status       	active   	2018-10-07 23:02:41	2018-10-07 23:03:41	-                  	-      	
8 	-       	Drupal_Archive    	succeeded	2018-10-07 23:02:41	2018-10-07 23:03:41	2018-10-07 23:13:41	-
```
### Run a task
```
$ lagoon run drush-archivedump -p high-cotton -e master
Result: success
id: 33
```
# Closes
closes #4 