### PR TITLE
Add non-existing config flags for ui and kibana urls

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -21,6 +21,8 @@ type LagoonConfigFlags struct {
 	Port     string `json:"port,omitempty"`
 	GraphQL  string `json:"graphql,omitempty"`
 	Token    string `json:"token,omitempty"`
+	UI       string `json:"ui,omitempty"`
+	Kibana   string `json:"kibana,omitempty"`
 }
 
 func parseLagoonConfig(flags pflag.FlagSet) LagoonConfigFlags {
@@ -45,7 +47,7 @@ var configCmd = &cobra.Command{
 }
 
 var configDefaultCmd = &cobra.Command{
-	Use:   "default [-l lagoonname]",
+	Use:   "default",
 	Short: "Set the default Lagoon to use",
 	Run: func(cmd *cobra.Command, args []string) {
 		lagoonConfig := parseLagoonConfig(*cmd.Flags())
@@ -68,7 +70,6 @@ var configDefaultCmd = &cobra.Command{
 			},
 		}
 		output.RenderResult(resultData, outputOptions)
-		//fmt.Println(fmt.Sprintf("Updating default lagoon to %s", lagoonName))
 	},
 }
 
@@ -86,6 +87,8 @@ var configLagoonsCmd = &cobra.Command{
 				fmt.Println(fmt.Sprintf(" - %s: %s", aurora.Yellow("Hostname"), viper.GetString("lagoons."+lagoon.String()+".hostname")))
 				fmt.Println(fmt.Sprintf(" - %s: %s", aurora.Yellow("GraphQL"), viper.GetString("lagoons."+lagoon.String()+".graphql")))
 				fmt.Println(fmt.Sprintf(" - %s: %d", aurora.Yellow("Port"), viper.GetInt("lagoons."+lagoon.String()+".port")))
+				fmt.Println(fmt.Sprintf(" - %s: %d", aurora.Yellow("UI"), viper.GetInt("lagoons."+lagoon.String()+".ui")))
+				fmt.Println(fmt.Sprintf(" - %s: %d", aurora.Yellow("Kibana"), viper.GetInt("lagoons."+lagoon.String()+".kibana")))
 			}
 			fmt.Println("\nYour default Lagoon is:")
 			fmt.Println(fmt.Sprintf("%s: %s\n", aurora.Yellow("Name"), viper.Get("default")))
@@ -99,6 +102,8 @@ var configLagoonsCmd = &cobra.Command{
 					"hostname": viper.GetString("lagoons." + lagoon.String() + ".hostname"),
 					"graphql":  viper.GetString("lagoons." + lagoon.String() + ".graphql"),
 					"port":     viper.GetString("lagoons." + lagoon.String() + ".port"),
+					"ui":       viper.GetString("lagoons." + lagoon.String() + ".ui"),
+					"kibana":   viper.GetString("lagoons." + lagoon.String() + ".Kibana"),
 				}
 				lagoonsData = append(lagoonsData, lagoonMapData)
 			}
@@ -128,6 +133,12 @@ var configAddCmd = &cobra.Command{
 			viper.Set("lagoons."+lagoonConfig.Lagoon+".hostname", lagoonConfig.Hostname)
 			viper.Set("lagoons."+lagoonConfig.Lagoon+".port", lagoonConfig.Port)
 			viper.Set("lagoons."+lagoonConfig.Lagoon+".graphql", lagoonConfig.GraphQL)
+			if lagoonConfig.UI != "" {
+				viper.Set("lagoons."+lagoonConfig.Lagoon+".ui", lagoonConfig.UI)
+			}
+			if lagoonConfig.Kibana != "" {
+				viper.Set("lagoons."+lagoonConfig.Lagoon+".kibana", lagoonConfig.Kibana)
+			}
 			if lagoonConfig.Token != "" {
 				viper.Set("lagoons."+lagoonConfig.Lagoon+".token", lagoonConfig.Token)
 			}
@@ -143,6 +154,8 @@ var configAddCmd = &cobra.Command{
 					"hostname": lagoonConfig.Hostname,
 					"graphql":  lagoonConfig.GraphQL,
 					"port":     lagoonConfig.Port,
+					"ui":       lagoonConfig.UI,
+					"kibana":   lagoonConfig.Kibana,
 				},
 			}
 			output.RenderResult(resultData, outputOptions)
@@ -153,7 +166,7 @@ var configAddCmd = &cobra.Command{
 }
 
 var configDeleteCmd = &cobra.Command{
-	Use:     "delete [-l lagoonname]",
+	Use:     "delete",
 	Aliases: []string{"d"},
 	Short:   "Delete a Lagoon instance configuration",
 	Run: func(cmd *cobra.Command, args []string) {
@@ -184,4 +197,6 @@ func init() {
 	configAddCmd.Flags().StringVarP(&lagoonPort, "port", "P", "", "Lagoon SSH port")
 	configAddCmd.Flags().StringVarP(&lagoonGraphQL, "graphql", "g", "", "Lagoon GraphQL endpoint")
 	configAddCmd.Flags().StringVarP(&lagoonToken, "token", "t", "", "Lagoon GraphQL token")
+	configAddCmd.Flags().StringVarP(&lagoonUI, "ui", "u", "", "Lagoon UI location (https://ui-lagoon-master.ch.amazee.io)")
+	configAddCmd.Flags().StringVarP(&lagoonKibana, "kibana", "k", "", "Lagoon Kibana URL (https://logs-db-ui-lagoon-master.ch.amazee.io)")
 }

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -37,25 +37,18 @@ var deleteProjectCmd = &cobra.Command{
 	Aliases: []string{"p"},
 	Short:   "Delete a project",
 	Run: func(cmd *cobra.Command, args []string) {
-		var projectName string
-		if len(args) < 1 {
-			if cmdProject.Name != "" {
-				projectName = cmdProject.Name
-			} else {
-				fmt.Println("Not enough arguments. Requires: project name")
-				cmd.Help()
-				os.Exit(1)
-			}
-		} else {
-			projectName = args[0]
+		if cmdProjectName == "" {
+			fmt.Println("Not enough arguments. Requires: project name")
+			cmd.Help()
+			os.Exit(1)
 		}
 
 		if !outputOptions.JSON {
-			fmt.Println(fmt.Sprintf("Deleting %s", projectName))
+			fmt.Println(fmt.Sprintf("Deleting %s", cmdProjectName))
 		}
 
 		if yesNo() {
-			deleteResult, err := projects.DeleteProject(projectName)
+			deleteResult, err := projects.DeleteProject(cmdProjectName)
 			if err != nil {
 				output.RenderError(err.Error(), outputOptions)
 				os.Exit(1)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -122,6 +122,7 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
 	rootCmd.AddCommand(deployCmd)
 	rootCmd.AddCommand(sshEnvCmd)
 	rootCmd.AddCommand(webCmd)
+	rootCmd.AddCommand(kibanaCmd)
 	rootCmd.AddCommand(versionCmd)
 }
 

--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -9,6 +9,8 @@ var lagoonHostname string
 var lagoonPort string
 var lagoonGraphQL string
 var lagoonToken string
+var lagoonUI string
+var lagoonKibana string
 
 // variable vars
 var variableValue string

--- a/cmd/web.go
+++ b/cmd/web.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/amazeeio/lagoon-cli/output"
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -14,16 +15,37 @@ var webCmd = &cobra.Command{
 	Use:   "web",
 	Short: "Launch the web user interface",
 	Run: func(cmd *cobra.Command, args []string) {
-
-		if len(args) < 1 {
+		if cmdProjectName == "" {
 			fmt.Println("Not enough arguments. Requires: project name")
+			cmd.Help()
 			os.Exit(1)
 		}
-		projectName := args[0]
 
 		urlBuilder := strings.Builder{}
 		urlBuilder.WriteString(viper.GetString("lagoons." + cmdLagoon + ".ui"))
-		urlBuilder.WriteString(fmt.Sprintf("/projects/%s", projectName))
+		if viper.GetString("lagoons."+cmdLagoon+".ui") != "" {
+			urlBuilder.WriteString(fmt.Sprintf("/projects/%s", cmdProjectName))
+		} else {
+			output.RenderError("unable to determine url for ui, is one set?", outputOptions)
+			os.Exit(1)
+		}
+
+		url := urlBuilder.String()
+		fmt.Println(fmt.Sprintf("Opening %s", url))
+		_ = browser.OpenURL(url)
+	},
+}
+
+var kibanaCmd = &cobra.Command{
+	Use:   "kibana",
+	Short: "Launch the kibana interface",
+	Run: func(cmd *cobra.Command, args []string) {
+		urlBuilder := strings.Builder{}
+		urlBuilder.WriteString(viper.GetString("lagoons." + cmdLagoon + ".kibana"))
+		if viper.GetString("lagoons."+cmdLagoon+".ui") == "" {
+			output.RenderError("unable to determine url for kibana, is one set?", outputOptions)
+			os.Exit(1)
+		}
 
 		url := urlBuilder.String()
 		fmt.Println(fmt.Sprintf("Opening %s", url))

--- a/docs/commands/lagoon.md
+++ b/docs/commands/lagoon.md
@@ -34,6 +34,7 @@ lagoon [flags]
 * [lagoon delete](lagoon_delete.md)	 - Delete a project, or delete notifications and variables from projects or environments
 * [lagoon deploy](lagoon_deploy.md)	 - deploy a branch or environment
 * [lagoon get](lagoon_get.md)	 - Get info on a project, or deployment
+* [lagoon kibana](lagoon_kibana.md)	 - Launch the kibana interface
 * [lagoon list](lagoon_list.md)	 - List projects, deployments, variables or notifications
 * [lagoon login](lagoon_login.md)	 - Log into a Lagoon instance
 * [lagoon run](lagoon_run.md)	 - Run a task against an environment

--- a/docs/commands/lagoon_config_add.md
+++ b/docs/commands/lagoon_config_add.md
@@ -16,8 +16,10 @@ lagoon config add [flags]
   -g, --graphql string    Lagoon GraphQL endpoint
   -h, --help              help for add
   -H, --hostname string   Lagoon SSH hostname
+  -k, --kibana string     Lagoon Kibana URL (https://logs-db-ui-lagoon-master.ch.amazee.io)
   -P, --port string       Lagoon SSH port
   -t, --token string      Lagoon GraphQL token
+  -u, --ui string         Lagoon UI location (https://ui-lagoon-master.ch.amazee.io)
 ```
 
 ### Options inherited from parent commands

--- a/docs/commands/lagoon_config_delete.md
+++ b/docs/commands/lagoon_config_delete.md
@@ -7,7 +7,7 @@ Delete a Lagoon instance configuration
 Delete a Lagoon instance configuration
 
 ```
-lagoon config delete [-l lagoonname] [flags]
+lagoon config delete [flags]
 ```
 
 ### Options

--- a/docs/commands/lagoon_kibana.md
+++ b/docs/commands/lagoon_kibana.md
@@ -1,19 +1,19 @@
-## lagoon config default
+## lagoon kibana
 
-Set the default Lagoon to use
+Launch the kibana interface
 
 ### Synopsis
 
-Set the default Lagoon to use
+Launch the kibana interface
 
 ```
-lagoon config default [flags]
+lagoon kibana [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for default
+  -h, --help   help for kibana
 ```
 
 ### Options inherited from parent commands
@@ -34,5 +34,5 @@ lagoon config default [flags]
 
 ### SEE ALSO
 
-* [lagoon config](lagoon_config.md)	 - Configure Lagoon CLI
+* [lagoon](lagoon.md)	 - Command line integration for Lagoon
 


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->
 
<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated.
- [x] Changelog entry has been written

With #40 and #41 there were missing config flags for non-default amazeeio lagoon configurations, this adds them in.

# Changelog Entry
<!--
Describe the change in order to make it visible in the changelog
If the change breaks anything document this - how was the functionality before - how does it work after the change

Prefix the change with: Feature, Change, Bugfix, Improvement, Documentation

Use following format:
Improvement - Description (#ISSUENUMBER)
-->
Improvement - Add additional flags for configuring non default amazeeio lagoon instances
