### PR TITLE
Attempt to use the SSH agent before looking for key files

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -26,11 +26,6 @@ var loginCmd = &cobra.Command{
 func publicKey(path string, skipAgent bool) (ssh.AuthMethod, func() error) {
 	noopCloseFunc := func() error { return nil }
 
-	key, err := ioutil.ReadFile(path)
-	if err != nil {
-		panic(err)
-	}
-
 	if skipAgent != true {
 		// Connect to SSH agent to ask for unencrypted private keys
 		if sshAgentConn, err := net.Dial("unix", os.Getenv("SSH_AUTH_SOCK")); err == nil {
@@ -43,6 +38,11 @@ func publicKey(path string, skipAgent bool) (ssh.AuthMethod, func() error) {
 				return ssh.PublicKeysCallback(sshAgent.Signers), sshAgentConn.Close
 			}
 		}
+	}
+
+	key, err := ioutil.ReadFile(path)
+	if err != nil {
+		panic(err)
 	}
 
 	// Try to look for an unencrypted private key


### PR DESCRIPTION
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [x] Changelog entry has been written

Try to use the SSH agent before attempting to open any SSH key files.
This offloads complex key handling, multiple key formats etc.

# Changelog Entry

Improvement - Prefer SSH agent over keyfile parsing.

# Closing issues
Closes #43 
