### PR TITLE
Add message to yesNo prompt

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -176,7 +176,7 @@ var configDeleteCmd = &cobra.Command{
 			os.Exit(1)
 		}
 		fmt.Println(fmt.Sprintf("Deleting config for lagoon: %s", lagoonConfig.Lagoon))
-		if yesNo() {
+		if yesNo("Are you sure?") {
 			err := unset(lagoonConfig.Lagoon)
 			if err != nil {
 				output.RenderError(err.Error(), outputOptions)

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -58,7 +58,7 @@ var deployBranchCmd = &cobra.Command{
 			fmt.Println(fmt.Sprintf("Deploying %s %s", cmdProjectName, deployBranch.Branch))
 		}
 
-		if yesNo() {
+		if yesNo("Continue with deployment?") {
 			deployResult, err := eClient.DeployEnvironmentBranch(cmdProjectName, deployBranch.Branch)
 			handleError(err)
 			resultData := output.Result{
@@ -88,7 +88,7 @@ var deployPromoteCmd = &cobra.Command{
 			fmt.Println(fmt.Sprintf("Promoting %s %s to %s", cmdProjectName, promoteEnv.Source, promoteEnv.Destination))
 		}
 
-		if yesNo() {
+		if yesNo("Continue with environment promotion?") {
 			deployResult, err := eClient.PromoteEnvironment(cmdProjectName, promoteEnv.Source, promoteEnv.Destination)
 			handleError(err)
 			resultData := output.Result{

--- a/cmd/environment.go
+++ b/cmd/environment.go
@@ -40,7 +40,7 @@ var deleteEnvCmd = &cobra.Command{
 		}
 		fmt.Println(fmt.Sprintf("Deleting %s-%s", cmdProjectName, cmdProjectEnvironment))
 
-		if yesNo() {
+		if yesNo("Are you sure you want to delete?") {
 			projectByName, err := eClient.DeleteEnvironment(cmdProjectName, cmdProjectEnvironment)
 			handleError(err)
 			resultData := output.Result{

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -46,7 +46,7 @@ var deleteProjectCmd = &cobra.Command{
 			fmt.Println(fmt.Sprintf("Deleting %s", cmdProjectName))
 		}
 
-		if yesNo() {
+		if yesNo("Are you sure you want to delete?") {
 			deleteResult, err := pClient.DeleteProject(cmdProjectName)
 			handleError(err)
 			resultData := output.Result{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -255,10 +255,10 @@ func initConfig() {
 
 }
 
-func yesNo() bool {
+func yesNo(message string) bool {
 	if forceAction != true {
 		prompt := promptui.Select{
-			Label: "Select[Yes/No]",
+			Label: message + "; Select[Yes/No]",
 			Items: []string{"No", "Yes"},
 		}
 		_, result, err := prompt.Run()

--- a/cmd/variables.go
+++ b/cmd/variables.go
@@ -108,7 +108,7 @@ var deleteVariableCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		if yesNo() {
+		if yesNo("Are you sure?") {
 			var deleteResult []byte
 			var err error
 			if cmdProjectEnvironment != "" {


### PR DESCRIPTION
# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [x] Changelog entry has been written

This copies some of the changes from @shreddedbacon's old import/export branch to add a message to the yes/no prompt.
This is in support of the import/export PR.


# Changelog Entry
Improvement - Add message to prompts


# Closing issues
n/a
