### PR TITLE
new line breaks ssh dial on darwin

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -85,7 +85,7 @@ func loginToken() error {
 	}
 	defer closeSSHAgent()
 
-	sshHost := fmt.Sprintf("%s:%s\n",
+	sshHost := fmt.Sprintf("%s:%s",
 		viper.GetString("lagoons."+cmdLagoon+".hostname"),
 		viper.GetString("lagoons."+cmdLagoon+".port"))
 	conn, err := ssh.Dial("tcp", sshHost, config)


### PR DESCRIPTION
The new line in the `sshHost` broke on darwin
```
Unable to refresh token, you may need to run `lagoon login` first, error was couldn't connect to ssh.lagoon.amazeeio.cloud:32222
: dial tcp: lookup tcp/32222
: nodename nor servname provided, or not known
```
Removing fixes it, @smlx can you verify if the new line is required on linux?