### PR TITLE
Environment variable to define the Lagoon cluster to use

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -238,12 +238,11 @@ func initConfig() {
 			os.Exit(1)
 		}
 	}
-	if cmdLagoon == "" {
-		if viper.GetString("default") == "" {
-			cmdLagoon = "amazeeio"
-		} else {
-			cmdLagoon = viper.GetString("default")
-		}
+	// get the lagoon context to use
+	err = helpers.GetLagoonContext(&cmdLagoon, rootCmd)
+	if err != nil {
+		output.RenderError(err.Error(), outputOptions)
+		os.Exit(1)
 	}
 	viper.Set("current", strings.TrimSpace(string(cmdLagoon))) // set the current lagoon to whatever we defined from config or as override in a flag
 

--- a/go.sum
+++ b/go.sum
@@ -61,10 +61,10 @@ github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASu
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/shlex v0.0.0-20181106134648-c34317bd91bf h1:7+FW5aGwISbqUtkfmIpZJGRgNFg2ioYPvFaUxdqpDsg=
 github.com/google/shlex v0.0.0-20181106134648-c34317bd91bf/go.mod h1:RpwtwJQFrIEPstU94h88MWPXP2ektJZ8cZ0YntAmXiE=
-github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
-github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
+github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gordonklaus/ineffassign v0.0.0-20180909121442-1003c8bd00dc h1:cJlkeAx1QYgO5N80aF5xRGstVsRQwgLR7uA2FnP1ZjY=
 github.com/gordonklaus/ineffassign v0.0.0-20180909121442-1003c8bd00dc/go.mod h1:cuNKsD1zp2v6XfE/orVX2QE1LC+i254ceGcVeDT3pTU=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 /*
@@ -44,6 +45,32 @@ func GetLagoonConfigFile(configPath *string, configName *string, configExtension
 		}
 		return fmt.Errorf("%s/%s File doesn't exist", *configPath, configFilePath)
 
+	}
+	// no config file found
+	return nil
+}
+
+// GetLagoonContext get the lagoon cluster to use
+func GetLagoonContext(lagoon *string, cmd *cobra.Command) error {
+	// check if we have an envvar or flag to define our lagoon context
+	var lagoonContext string
+	lagoonContext, err := cmd.Flags().GetString("lagoon")
+	if err != nil {
+		return err
+	}
+	if lagoonContext == "" {
+		if lagoonContextEnvar, ok := os.LookupEnv("LAGOONCONTEXT"); ok {
+			lagoonContext = lagoonContextEnvar
+		}
+	}
+	if lagoonContext != "" {
+		*lagoon = lagoonContext
+	} else {
+		if viper.GetString("default") == "" {
+			*lagoon = "amazeeio"
+		} else {
+			*lagoon = viper.GetString("default")
+		}
 	}
 	// no config file found
 	return nil

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -29,7 +29,7 @@ func GetLagoonConfigFile(configPath *string, configName *string, configExtension
 	var configFilePath string
 	configFilePath, err := cmd.Flags().GetString("config-file")
 	if err != nil {
-		return err
+		return fmt.Errorf("Error reading flag `config-file`: %v", err)
 	}
 	if configFilePath == "" {
 		if lagoonConfigEnvar, ok := os.LookupEnv("LAGOONCONFIG"); ok {
@@ -56,7 +56,7 @@ func GetLagoonContext(lagoon *string, cmd *cobra.Command) error {
 	var lagoonContext string
 	lagoonContext, err := cmd.Flags().GetString("lagoon")
 	if err != nil {
-		return err
+		return fmt.Errorf("Error reading flag `lagoon`: %v", err)
 	}
 	if lagoonContext == "" {
 		if lagoonContextEnvar, ok := os.LookupEnv("LAGOONCONTEXT"); ok {
@@ -72,7 +72,6 @@ func GetLagoonContext(lagoon *string, cmd *cobra.Command) error {
 			*lagoon = viper.GetString("default")
 		}
 	}
-	// no config file found
 	return nil
 }
 


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->
 
<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [x] Changelog entry has been written

Setting the envvar `LAGOONCONTEXT` to the name of the cluster to use to allow for overrides of the `default` value in the main lagoon config file for the cli.

```
export LAGOONCONTEXT=mycluster
```
Now any `lagoon x` commands will try to execute against `mycluster` instead of whichever may be defined in `default:` in the main `~/.lagoon.yml` file.

# Changelog Entry
<!--
Describe the change in order to make it visible in the changelog
If the change breaks anything document this - how was the functionality before - how does it work after the change

Prefix the change with: Feature, Change, Bugfix, Improvement, Documentation

Use following format:
Improvement - Description (#ISSUENUMBER)
-->
Improvement - New config related environment variable for defining cluster to use.

