### PR TITLE
Fix lagoon delete slack/rocketchat notification

### DIFF
--- a/cmd/notificationsrocketchat.go
+++ b/cmd/notificationsrocketchat.go
@@ -184,6 +184,7 @@ func init() {
 	addProjectRocketChatNotificationCmd.Flags().StringVarP(&notificationName, "name", "n", "", "The name of the notification")
 
 	deleteProjectRocketChatNotificationCmd.Flags().StringVarP(&notificationName, "name", "n", "", "The name of the notification")
+	deleteRocketChatNotificationCmd.Flags().StringVarP(&notificationName, "name", "n", "", "The name of the notification")
 
 	updateRocketChatNotificationCmd.Flags().StringVarP(&notificationName, "name", "n", "", "The current name of the notification")
 	updateRocketChatNotificationCmd.Flags().StringVarP(&notificationNewName, "newname", "N", "", "The name of the notification")

--- a/cmd/notificationsslack.go
+++ b/cmd/notificationsslack.go
@@ -189,6 +189,7 @@ func init() {
 	addProjectSlackNotificationCmd.Flags().StringVarP(&notificationName, "name", "n", "", "The name of the notification")
 
 	deleteProjectSlackNotificationCmd.Flags().StringVarP(&notificationName, "name", "n", "", "The name of the notification")
+	deleteSlackNotificationCmd.Flags().StringVarP(&notificationName, "name", "n", "", "The name of the notification")
 
 	updateSlackNotificationCmd.Flags().StringVarP(&notificationName, "name", "n", "", "The current name of the notification")
 	updateSlackNotificationCmd.Flags().StringVarP(&notificationNewName, "newname", "N", "", "The name of the notification")


### PR DESCRIPTION
This PR fixes the `lagoon delete slack` and `lagoon delete rocketchat` commands due to the lack of `-n` flag
 
<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [x] Changelog entry has been written

Since this PR is not possible to delete a slack or rocketchat notification

# Changelog Entry
Bugfix - Fix slack/rocketchat notification deletion  (#130)

# Closing issues
closes #130 
