### PR TITLE
Added Dockerfile to build lagoon-cli image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM golang:1.14 as build
+
+WORKDIR /go/src/github.com/amazeeio/lagoon-cli/
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux go build \
+    -ldflags '-w -s -X /go/src/source/cmd.lagoonCLIBuild=1 \
+    -X /go/src/source/cmd.lagoonCLIBuildGoVersion=1.14"' \
+    -o lagoon .
+
+FROM alpine:3.11 
+
+WORKDIR /root/
+COPY --from=build /go/src/github.com/amazeeio/lagoon-cli/lagoon /lagoon
+ENTRYPOINT ["/lagoon"]


### PR DESCRIPTION
Adding a Dockerfile to the repo so dockerhub can build out an image to use lagoon CLI via docker.

Tested build via `8thom/lagoon-cli`

Example: `docker run -ti -v $HOME:/root 8thom/lagoon-cli list projects`

*Requires your home directory to be mounted for access to the SSH keys and `~/.lagoon.yml` config.