### PR TITLE
Add 'chmod' command to release template for OSX/Linux binary instructions

### DIFF
--- a/builds/release_template.md
+++ b/builds/release_template.md
@@ -11,8 +11,8 @@ brew install lagoon
 Alternatively, you may install by downloading one of the pre-compiled binaries
 ```
 # MacOS
-sudo curl -L "https://github.com/amazeeio/lagoon-cli/releases/download/CIRCLE_TAG/lagoon-cli-CIRCLE_TAG-darwin-amd64" -o /usr/local/bin/lagoon
+sudo curl -L "https://github.com/amazeeio/lagoon-cli/releases/download/CIRCLE_TAG/lagoon-cli-CIRCLE_TAG-darwin-amd64" -o /usr/local/bin/lagoon && sudo chmod +x /usr/local/bin/lagoon
 
 # Linux
-sudo curl -L "https://github.com/amazeeio/lagoon-cli/releases/download/CIRCLE_TAG/lagoon-cli-CIRCLE_TAG-linux-amd64" -o /usr/local/bin/lagoon
+sudo curl -L "https://github.com/amazeeio/lagoon-cli/releases/download/CIRCLE_TAG/lagoon-cli-CIRCLE_TAG-linux-amd64" -o /usr/local/bin/lagoon && sudo chmod +x /usr/local/bin/lagoon
 ```


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->
 
<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [X] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [ ] Changelog entry has been written

When first downloaded into a user's PATH, the binary is not executable. This PR just adds a `chmod` command to the instructions in the release template.

# Changelog Entry
<!--
Describe the change in order to make it visible in the changelog
If the change breaks anything document this - how was the functionality before - how does it work after the change

Prefix the change with: Feature, Change, Bugfix, Improvement, Documentation

Use following format:
Improvement - Description (#ISSUENUMBER)
-->

Documentation - Update binary installation instructions to include setting executable permissions on the downloaded file (#157)


# Closing issues
closes #157 
