### PR TITLE
Transform email addresses to lowercase

### DIFF
--- a/cmd/groups.go
+++ b/cmd/groups.go
@@ -71,7 +71,7 @@ var addUserToGroupCmd = &cobra.Command{
 		}
 		userGroupRole := api.UserGroupRole{
 			User: api.User{
-				Email: userEmail,
+				Email: strings.ToLower(userEmail),
 			},
 			Group: api.Group{
 				Name: groupName,
@@ -140,7 +140,7 @@ var deleteUserFromGroupCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		userGroupRole := api.UserGroup{
 			User: api.User{
-				Email: userEmail,
+				Email: strings.ToLower(userEmail),
 			},
 			Group: api.Group{
 				Name: groupName,

--- a/cmd/users.go
+++ b/cmd/users.go
@@ -23,6 +23,8 @@ func parseUser(flags pflag.FlagSet) api.User {
 	jsonStr, _ := json.Marshal(configMap)
 	parsedFlags := api.User{}
 	json.Unmarshal(jsonStr, &parsedFlags)
+	// lowercase user email address
+	parsedFlags.Email = strings.ToLower(parsedFlags.Email)
 	return parsedFlags
 }
 
@@ -188,7 +190,7 @@ var updateUserCmd = &cobra.Command{
 		var customReqResult []byte
 		var err error
 		currentUser := api.User{
-			Email: currentUserEmail,
+			Email: strings.ToLower(currentUserEmail),
 		}
 		customReqResult, err = uClient.ModifyUser(currentUser, userFlags)
 		handleError(err)
@@ -215,13 +217,13 @@ var getUserKeysCmd = &cobra.Command{
 			cmd.Help()
 			os.Exit(1)
 		}
-		returnedJSON, err := uClient.ListUserSSHKeys(groupName, userEmail, false)
+		returnedJSON, err := uClient.ListUserSSHKeys(groupName, strings.ToLower(userEmail), false)
 		handleError(err)
 		var dataMain output.Table
 		err = json.Unmarshal([]byte(returnedJSON), &dataMain)
 		handleError(err)
 		if len(dataMain.Data) == 0 {
-			output.RenderInfo(fmt.Sprintf("No ssh-keys for user '%s'", userEmail), outputOptions)
+			output.RenderInfo(fmt.Sprintf("No ssh-keys for user '%s'", strings.ToLower(userEmail)), outputOptions)
 			os.Exit(0)
 		}
 		output.RenderOutput(dataMain, outputOptions)
@@ -236,7 +238,7 @@ var getAllUserKeysCmd = &cobra.Command{
 	Short:   "Get all user SSH keys",
 	Long:    `Get all user SSH keys. This will only work for users that are part of a group`,
 	Run: func(cmd *cobra.Command, args []string) {
-		returnedJSON, err := uClient.ListUserSSHKeys(groupName, userEmail, true)
+		returnedJSON, err := uClient.ListUserSSHKeys(groupName, strings.ToLower(userEmail), true)
 		handleError(err)
 		var dataMain output.Table
 		err = json.Unmarshal([]byte(returnedJSON), &dataMain)


### PR DESCRIPTION

 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->
 
<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [ ] Changelog entry has been written

In Lagoon, user account email addresses automatically get transformed into lowercase. Either by Keycloak, or somewhere in the API. This forces email addresses entered by users to be lowercase when being sent to the Lagoon API.

An extra issue needs to be raised against Lagoon to do this in the API itself.

# Changelog Entry
<!--
Describe the change in order to make it visible in the changelog
If the change breaks anything document this - how was the functionality before - how does it work after the change

Prefix the change with: Feature, Change, Bugfix, Improvement, Documentation

Use following format:
Improvement - Description (#ISSUENUMBER)
-->

# Closing issues
Closes #168 
