### PR TITLE
make sure the cli correctly knows which lagoon to use

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -236,7 +236,7 @@ var configLagoonVersionCmd = &cobra.Command{
 	Aliases: []string{"l"},
 	Short:   "Checks the current Lagoon for its version and sets it in the config file",
 	PreRunE: func(_ *cobra.Command, _ []string) error {
-		return validateTokenE(cmdLagoon)
+		return validateTokenE(lagoonCLIConfig.Current)
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		debug, err := cmd.Flags().GetBool("debug")

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -82,8 +82,8 @@ func loginToken() error {
 	defer closeSSHAgent()
 
 	sshHost := fmt.Sprintf("%s:%s",
-		lagoonCLIConfig.Lagoons[cmdLagoon].HostName,
-		lagoonCLIConfig.Lagoons[cmdLagoon].Port)
+		lagoonCLIConfig.Lagoons[lagoonCLIConfig.Current].HostName,
+		lagoonCLIConfig.Lagoons[lagoonCLIConfig.Current].Port)
 	conn, err := ssh.Dial("tcp", sshHost, config)
 	if err != nil {
 		return fmt.Errorf("couldn't connect to %s: %v", sshHost, err)
@@ -100,9 +100,9 @@ func loginToken() error {
 		return fmt.Errorf("couldn't get token: %v", err)
 	}
 
-	lc := lagoonCLIConfig.Lagoons[cmdLagoon]
+	lc := lagoonCLIConfig.Lagoons[lagoonCLIConfig.Current]
 	lc.Token = strings.TrimSpace(string(out))
-	lagoonCLIConfig.Lagoons[cmdLagoon] = lc
+	lagoonCLIConfig.Lagoons[lagoonCLIConfig.Current] = lc
 	if err = writeLagoonConfig(&lagoonCLIConfig, filepath.Join(configFilePath, configName+configExtension)); err != nil {
 		return fmt.Errorf("couldn't write config: %v", err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -229,7 +229,7 @@ func initConfig() {
 		output.RenderError(err.Error(), outputOptions)
 		os.Exit(1)
 	}
-	err = getLagoonContext(&cmdLagoon, rootCmd)
+	err = getLagoonContext(&lagoonCLIConfig, &cmdLagoon, rootCmd)
 	if err != nil {
 		output.RenderError(err.Error(), outputOptions)
 		os.Exit(1)
@@ -439,8 +439,7 @@ func getLagoonConfigFile(configPath *string, configName *string, configExtension
 	return nil
 }
 
-func getLagoonContext(lagoon *string, cmd *cobra.Command) error {
-	lagoonCLIConfig.Current = strings.TrimSpace(string(cmdLagoon))
+func getLagoonContext(lagoonCLIConfig *lagoon.Config, lagoon *string, cmd *cobra.Command) error {
 	// check if we have an envvar or flag to define our lagoon context
 	var lagoonContext string
 	lagoonContext, err := cmd.Flags().GetString("lagoon")
@@ -461,5 +460,7 @@ func getLagoonContext(lagoon *string, cmd *cobra.Command) error {
 			*lagoon = lagoonCLIConfig.Default
 		}
 	}
+	// set the Current lagoon to the one we've determined it needs to be
+	lagoonCLIConfig.Current = strings.TrimSpace(*lagoon)
 	return nil
 }

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -27,8 +27,8 @@ var sshEnvCmd = &cobra.Command{
 			os.Exit(1)
 		}
 		sshConfig := map[string]string{
-			"hostname": lagoonCLIConfig.Lagoons[cmdLagoon].HostName,
-			"port":     lagoonCLIConfig.Lagoons[cmdLagoon].Port,
+			"hostname": lagoonCLIConfig.Lagoons[lagoonCLIConfig.Current].HostName,
+			"port":     lagoonCLIConfig.Lagoons[lagoonCLIConfig.Current].Port,
 			"username": cmdProjectName + "-" + cmdProjectEnvironment,
 		}
 		if sshConnString {

--- a/cmd/web.go
+++ b/cmd/web.go
@@ -22,8 +22,8 @@ var webCmd = &cobra.Command{
 		}
 
 		urlBuilder := strings.Builder{}
-		urlBuilder.WriteString(lagoonCLIConfig.Lagoons[cmdLagoon].UI)
-		if lagoonCLIConfig.Lagoons[cmdLagoon].UI != "" {
+		urlBuilder.WriteString(lagoonCLIConfig.Lagoons[lagoonCLIConfig.Current].UI)
+		if lagoonCLIConfig.Lagoons[lagoonCLIConfig.Current].UI != "" {
 			urlBuilder.WriteString(fmt.Sprintf("/projects/%s", cmdProjectName))
 		} else {
 			output.RenderError("unable to determine url for ui, is one set?", outputOptions)
@@ -42,8 +42,8 @@ var kibanaCmd = &cobra.Command{
 	Short:   "Launch the kibana interface",
 	Run: func(cmd *cobra.Command, args []string) {
 		urlBuilder := strings.Builder{}
-		urlBuilder.WriteString(lagoonCLIConfig.Lagoons[cmdLagoon].Kibana)
-		if lagoonCLIConfig.Lagoons[cmdLagoon].Kibana == "" {
+		urlBuilder.WriteString(lagoonCLIConfig.Lagoons[lagoonCLIConfig.Current].Kibana)
+		if lagoonCLIConfig.Lagoons[lagoonCLIConfig.Current].Kibana == "" {
 			output.RenderError("unable to determine url for kibana, is one set?", outputOptions)
 			os.Exit(1)
 		}


### PR DESCRIPTION
 <!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:
 -->
 
<!-- You can skip this if you're fixing a typo. -->
# Checklist
- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated.
- [ ] Changelog entry has been written

After PR #179 was merged, it uncovered a slight problem where if the `--lagoon $lagoon` flag was not defined, the CLI got confused and was unable to determine which lagoon from the config file to target.

This PR makes sure that the `current` lagoon is set in the correct location and updates commands to use the correct current value.

# Changelog Entry
<!--
Describe the change in order to make it visible in the changelog
If the change breaks anything document this - how was the functionality before - how does it work after the change

Prefix the change with: Feature, Change, Bugfix, Improvement, Documentation

Use following format:
Improvement - Description (#ISSUENUMBER)
-->

# Closing issues
closes #182 
