### PR TITLE
Add installation method to show on the docs site

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,5 +9,14 @@ If you run the CLI in a directory that has a valid `.lagoon.yml` and `docker-com
 # Requirements
 To use this CLI, you need an account in the Lagoon that you wish to communicate with, and your SSH key needs to be associated to your account.
 
+# Installation
+The preferred method to install is via [Homebrew](https://brew.sh/).
+```
+brew tap amazeeio/lagoon-cli
+brew install lagoon
+```
+
+Alternatively, you may install by downloading one of the pre-compiled binaries from the [releases page](https://github.com/amazeeio/lagoon-cli/releases)
+
 # Usage
 See [Commands](commands/lagoon.md)


### PR DESCRIPTION
Adds the installation method to https://amazeeio.github.io/lagoon-cli/